### PR TITLE
'clicshop3312.customers_groups' doesn't exist

### DIFF
--- a/install/clicshopping_en.sql
+++ b/install/clicshopping_en.sql
@@ -1785,8 +1785,7 @@ INSERT INTO currencies VALUES(1, 'Euro', 'EUR', '', 'EUR', '.', ',', '2', 1.0000
 INSERT INTO currencies VALUES(2, 'Dollard', 'USD', 'USD', '', '.', ',', '2', 1.40750003, '2008-09-13 18:02:36', 1, 0);
 INSERT INTO currencies VALUES(3, 'Canada', 'CAD', '', 'CAD', '.', '.', '2', 1.50580001, '2008-09-13 18:02:36', 1, 0);
 
-INSERT INTO customers_groups VALUES(1, 'Client Normal', '0.00', '3BFF0A', 0, 'CO', 'IT', 'true', 0);
-INSERT INTO customers_groups VALUES(2, 'Tarifs 1', '5.00', 'FF0000', 0, 'CO', 'IT', 'true', 0);
+INSERT INTO customers_groups VALUES(1, 'Tarifs 1', '5.00', 'FF0000', 0, 'CO', 'IT', 'true', 0);
 
 INSERT INTO geo_zones VALUES(1, 'France', 'Etat français avec tous les départements', '2016-12-03 11:34:53', '2006-04-11 18:48:30');
 INSERT INTO geo_zones VALUES(2, 'Etats membres de l\'UE', 'Etats membres de l\'union européenne', '2016-12-03 11:34:30', '2006-05-04 10:27:42');

--- a/install/clicshopping_en.sql
+++ b/install/clicshopping_en.sql
@@ -1785,7 +1785,8 @@ INSERT INTO currencies VALUES(1, 'Euro', 'EUR', '', 'EUR', '.', ',', '2', 1.0000
 INSERT INTO currencies VALUES(2, 'Dollard', 'USD', 'USD', '', '.', ',', '2', 1.40750003, '2008-09-13 18:02:36', 1, 0);
 INSERT INTO currencies VALUES(3, 'Canada', 'CAD', '', 'CAD', '.', '.', '2', 1.50580001, '2008-09-13 18:02:36', 1, 0);
 
-INSERT INTO customers_groups VALUES(1, 'Client Normal', '0.00', '3BFF0A', 0, 'CO', 'IT', 'true', 0);INSERT INTO customers_groups VALUES(2, 'Tarifs 1', '5.00', 'FF0000', 0, 'CO', 'IT', 'true', 0);
+INSERT INTO customers_groups VALUES(1, 'Client Normal', '0.00', '3BFF0A', 0, 'CO', 'IT', 'true', 0);
+INSERT INTO customers_groups VALUES(2, 'Tarifs 1', '5.00', 'FF0000', 0, 'CO', 'IT', 'true', 0);
 
 INSERT INTO geo_zones VALUES(1, 'France', 'Etat français avec tous les départements', '2016-12-03 11:34:53', '2006-04-11 18:48:30');
 INSERT INTO geo_zones VALUES(2, 'Etats membres de l\'UE', 'Etats membres de l\'union européenne', '2016-12-03 11:34:30', '2006-05-04 10:27:42');


### PR DESCRIPTION
Hi,

I am trying to install ClicShopping 3.312 but getting error while install

![image](https://user-images.githubusercontent.com/12833130/154008846-fcd7e5e0-997e-4ed1-a0b4-ec71f2abbc8a.png)

After debug i found 
ClicShopping make queries line by line only
but two queries are made in single line it will change prefix of first only that causing error.

https://github.com/ClicShopping/ClicShopping_V3/blob/9558e6a88a80d53abb402765d188f0a105717f0a/includes/ClicShopping/OM/Db.php#L510-L523

it don't add prefix to second query if its in single line